### PR TITLE
[DCA-37] Move dns and cert creation out of cdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,26 @@ to store secrets for this project.  An AWS best practice is to create secrets
 with a unique ID to prevent conflicts when multiple instances of this project
 is deployed to the same AWS account.  Our naming convention is
 `<cfn stack id>/<environment id>/<secret name>`.  An example is `MyTestStack/dev/MySecret`
+
+
+## DNS and Certificates
+
+Sage IT manages the creation of DNS records and TLS certificates in [org-formation](https://github.com/Sage-Bionetworks-IT/organizations-infra/tree/master/org-formation).
+The DNS records are managed centrally in the SageIT account, and corresponding
+wildcard TLS certificates are created in any application accounts that will
+deploy applications with custom (non-AWS) domains.
+
+When deploying a new application (or an existing application to a new account,
+e.g. the first deploy to "prod"), first check that a certificate for the
+desired domain has been created in the account the application will be deployed
+to (e.g. [here for app.sagebionetworks.org](https://github.com/Sage-Bionetworks-IT/organizations-infra/blob/master/org-formation/100-shared-dns/_tasks.yaml#L24-L27)).
+If a certificate is needed in a new account, make a request to the IT team
+because there is a manual validation step that must be performed by an
+administrator. Set the value of `ACM_CERT_ARN` context variable to the ARN of
+the certificate in the target account. If the AWS ARN for an existing
+certificate is not known, it can be requested from Sage IT.
+
+Finally, a DNS CNAME must be created in org-formation after the initial
+deployment of the application to make the application available at the desired
+URL. The CDK application exports the DNS name of the Application Load Balancer
+to be consumed in org-formation. [An example PR setting up a CNAME](https://github.com/Sage-Bionetworks-IT/organizations-infra/pull/739).

--- a/cdk.json
+++ b/cdk.json
@@ -36,9 +36,7 @@
       "PORT": "7080",
       "COST_CENTER": "NO PROGRAM / 000000",
       "STACK_NAME_PREFIX": "schematic",
-      "HOST_NAME": "schematic.dnt-dev.sagebase.org",
-      "HOSTED_ZONE_NAME": "dnt-dev.sagebase.org",
-      "HOSTED_ZONE_ID": "Z0441843EAHKE7DR12AX",
+      "ACM_CERT_ARN": "arn:aws:acm:us-east-1:631692904429:certificate/8644a975-2c1d-49ca-bc73-786745db0bc8",
       "VPC_CIDR": "10.255.73.0/24"
     }
   }

--- a/docker_fargate/docker_fargate_stack.py
+++ b/docker_fargate/docker_fargate_stack.py
@@ -1,22 +1,21 @@
-
 from aws_cdk import (Stack,
     aws_ec2 as ec2,
     aws_ecs as ecs,
     aws_ecs_patterns as ecs_patterns,
     aws_elasticloadbalancingv2 as elbv2,
     aws_route53 as r53,
+    CfnOutput,
     Duration,
     Tags)
 
 import config as config
+import aws_cdk.aws_certificatemanager as cm
 import aws_cdk.aws_secretsmanager as sm
 from constructs import Construct
 
+ACM_CERT_ARN_CONTEXT = "ACM_CERT_ARN"
 IMAGE_PATH_AND_TAG_CONTEXT = "IMAGE_PATH_AND_TAG"
 PORT_NUMBER_CONTEXT = "PORT"
-HOST_NAME_CONTEXT = "HOST_NAME"
-HOSTED_ZONE_NAME_CONTEXT = "HOSTED_ZONE_NAME"
-HOSTED_ZONE_ID_CONTEXT = "HOSTED_ZONE_ID"
 
 # The name of the environment variable that will hold the secrets
 SECRETS_MANAGER_ENV_NAME = "SECRETS_MANAGER_SECRETS"
@@ -32,14 +31,8 @@ def get_secret(scope: Construct, id: str, name: str) -> str:
 def get_container_env(env: dict) -> str:
     return env.get(CONTAINER_ENV)
 
-def get_hosted_zone_name(env: dict) -> str:
-    return env.get(HOSTED_ZONE_NAME_CONTEXT)
-
-def get_hosted_zone_id(env: dict) -> str:
-    return env.get(HOSTED_ZONE_ID_CONTEXT)
-
-def get_host_name(env: dict) -> str:
-    return env.get(HOST_NAME_CONTEXT)
+def get_certificate_arn(env: dict) -> str:
+    return env.get(ACM_CERT_ARN_CONTEXT)
 
 def get_docker_image_name(env: dict):
     return env.get(IMAGE_PATH_AND_TAG_CONTEXT)
@@ -77,12 +70,11 @@ class DockerFargateStack(Stack):
                    secrets = secrets,
                    container_port = get_port(env))
 
-        zone = r53.PublicHostedZone.from_public_hosted_zone_attributes(
+        cert = cm.Certificate.from_certificate_arn(
             self,
-            id=f'{stack_id}_zone',
-            hosted_zone_id=get_hosted_zone_id(env),
-            zone_name=get_hosted_zone_name(env))
-
+            f'{stack_id}-Certificate',
+            get_certificate_arn(env),
+        )
 
         #
         # for options to pass to ApplicationLoadBalancedTaskImageOptions see:
@@ -99,10 +91,10 @@ class DockerFargateStack(Stack):
             memory_limit_mib=1024,      # Default is 512
             public_load_balancer=True,  # Default is False
             # TLS:
+            certificate=cert,
             protocol=elbv2.ApplicationProtocol.HTTPS,
             ssl_policy=elbv2.SslPolicy.FORWARD_SECRECY_TLS12_RES, # Strong forward secrecy ciphers and TLS1.2 only.
-            domain_name=get_host_name(env), # The domain name for the service, e.g. “api.example.com.”
-            domain_zone=zone) #  The Route53 hosted zone for the domain, e.g. “example.com.”
+        )
 
         # Overriding health check timeout helps with sluggishly responding app's (e.g. Shiny)
         # https://docs.aws.amazon.com/cdk/api/v1/python/aws_cdk.aws_elasticloadbalancingv2/ApplicationTargetGroup.html#aws_cdk.aws_elasticloadbalancingv2.ApplicationTargetGroup
@@ -132,3 +124,8 @@ class DockerFargateStack(Stack):
 
         # Tag all resources in this Stack's scope with a cost center tag
         Tags.of(scope).add(config.COST_CENTER_CONTEXT, env.get(config.COST_CENTER_CONTEXT))
+
+        # Export load balancer name
+        lb_dns_name = load_balanced_fargate_service.load_balancer.load_balancer_dns_name
+        lb_dns_export_name = f'{stack_id}-LoadBalancerDNS'
+        CfnOutput(self, 'LoadBalancerDNS', value=lb_dns_name, export_name=lb_dns_export_name)


### PR DESCRIPTION
Move the creation of the ACM certificate and DNS records out
of CDK and into org-formation by referencing the ARN of an existing
certificate and outputting the DNS name of the load balancer.