### PR TITLE
switch back to previous version to test speed

### DIFF
--- a/cdk.json
+++ b/cdk.json
@@ -31,7 +31,7 @@
       "aws-cn"
     ],
     "dev": {
-      "IMAGE_PATH_AND_TAG": "ghcr.io/sage-bionetworks/schematic:0.1.33-beta",
+      "IMAGE_PATH_AND_TAG": "ghcr.io/sage-bionetworks/schematic:0.1.32-beta",
       "AWS_DEFAULT_REGION": "us-east-1",
       "PORT": "7080",
       "COST_CENTER": "NO PROGRAM / 000000",


### PR DESCRIPTION
PR Checklist:
[X] Describe and explain your intentions for this change
[X] Setup pre-commit and run the validators (info in README.md)

For some reasons, the newer version (v0.1.33-beta) appears to be much slower. I want to switch back to v0.1.32-beta and see if the endpoints respond faster or is it because AWS happens to be sluggish. 

some stats for reference: 
* `manifest/generate` (should be exactly the same for v0.1.33-beta and v0.1.32-beta): For getting a new manifest by using the example data model as an excel format, the older version took around 66s (when concurrent request = 20), but I tested it just now and it took on average 86s 
* `manifest/validate` (should be slightly different between these two version. But the change shouldn't affect speed): for validating a 178 bytes manifest with 20 concurrent requests as an excel format (using the example data model), the older version took around 26s while the newer version took around ~100s
