### PR TITLE
fix staging environment

### DIFF
--- a/cdk.json
+++ b/cdk.json
@@ -48,7 +48,7 @@
       "TAGS": {
         "CostCenter": "NO PROGRAM / 000000"
       },
-      "STACK_NAME_PREFIX": "schematic",
+      "STACK_NAME_PREFIX": "schematic-staging",
       "ACM_CERT_ARN": "arn:aws:acm:us-east-1:878654265857:certificate/d11fba3c-1957-48ba-9be0-8b1f460ee970",
       "VPC_CIDR": "10.255.75.0/24"
     },


### PR DESCRIPTION
The staging STACK_NAME_PREFIX context requires a unique name otherwise it will overwrite an existing cloudformation stack.

