### PR TITLE
Reverted back to port `7080` instead of using port `443`

### DIFF
--- a/cdk.json
+++ b/cdk.json
@@ -31,9 +31,9 @@
       "aws-cn"
     ],
     "dev": {
-      "IMAGE_PATH_AND_TAG": "ghcr.io/sage-bionetworks/schematic:0.1.49-beta",
+      "IMAGE_PATH_AND_TAG": "ghcr.io/sage-bionetworks/schematic:v23.6.3",
       "AWS_DEFAULT_REGION": "us-east-1",
-      "PORT": "7080",
+      "PORT": "443",
       "TAGS": {
         "CostCenter": "NO PROGRAM / 000000"
       },

--- a/cdk.json
+++ b/cdk.json
@@ -33,7 +33,7 @@
     "dev": {
       "IMAGE_PATH_AND_TAG": "ghcr.io/sage-bionetworks/schematic:0.1.49-beta",
       "AWS_DEFAULT_REGION": "us-east-1",
-      "PORT": "443",
+      "PORT": "7080",
       "TAGS": {
         "CostCenter": "NO PROGRAM / 000000"
       },


### PR DESCRIPTION
PR Checklist:
[X] Describe and explain your intentions for this change
[X] Setup pre-commit and run the validators (info in README.md)

Based on conversation with @zaro0508 here in slack: https://sagebionetworks.slack.com/archives/CEFQD0KU1/p1687882067270409?thread_ts=1687470630.012629&cid=CEFQD0KU1, try using port 7080 to trouble shoot the load balancer. 
