### PR TITLE
Deploy schematic v0.1.59-beta to dev AWS instance

### DIFF
--- a/cdk.json
+++ b/cdk.json
@@ -31,7 +31,7 @@
       "aws-cn"
     ],
     "dev": {
-      "IMAGE_PATH_AND_TAG": "ghcr.io/sage-bionetworks/schematic:v0.1.59-beta",
+      "IMAGE_PATH_AND_TAG": "ghcr.io/sage-bionetworks/schematic:0.1.59-beta",
       "AWS_DEFAULT_REGION": "us-east-1",
       "PORT": "443",
       "TAGS": {


### PR DESCRIPTION
PR deploys a beta version of schematic to dev so that the API auth changes can be tested, fixing the incorrect tag specification from #68 

PR Checklist:
[ x] Describe and explain your intentions for this change
[ x] Setup pre-commit and run the validators (info in README.md)