### PR TITLE
Deploy schematic `v23.9.3` to dev (fix failing gh action)

### DIFF
--- a/cdk.json
+++ b/cdk.json
@@ -31,7 +31,7 @@
       "aws-cn"
     ],
     "dev": {
-      "IMAGE_PATH_AND_TAG": "ghcr.io/sage-bionetworks/schematic:v23.9.3-beta",
+      "IMAGE_PATH_AND_TAG": "ghcr.io/sage-bionetworks/schematic:v23.9.3",
       "AWS_DEFAULT_REGION": "us-east-1",
       "PORT": "443",
       "TAGS": {


### PR DESCRIPTION
Retry deploying v23.9.3 to dev. Had to remove `-beta` from the schematic version

PR Checklist:
[x] Describe and explain your intentions for this change
[x] Setup pre-commit and run the validators (info in README.md)
