### PR TITLE
Redeploy schematic 23.11.2 due to missing import statements

### DIFF
--- a/cdk.json
+++ b/cdk.json
@@ -42,7 +42,7 @@
       "VPC_CIDR": "10.255.73.0/24"
     },
     "dev-refactor": {
-      "IMAGE_PATH_AND_TAG": "ghcr.io/sage-bionetworks/schematic:23.11.2-dev",
+      "IMAGE_PATH_AND_TAG": "ghcr.io/sage-bionetworks/schematic:23.11.2-dev1",
       "AWS_DEFAULT_REGION": "us-east-1",
       "PORT": "443",
       "TAGS": {


### PR DESCRIPTION
PR Checklist:
[ ] Describe and explain your intentions for this change
[ ] Setup pre-commit and run the validators (info in README.md)

When I did smoke testing, I noticed that some endpoints didn't work. See issue: FDS 1385 for more details. After adding the import statements back, I built another docker image: `23.11.2-dev1`. This PR is for deploying `23.11.2-dev1` to `dev-refactor` instance. 