### PR TITLE
Increase load balancer idle time out

### DIFF
--- a/cdk.json
+++ b/cdk.json
@@ -31,7 +31,7 @@
       "aws-cn"
     ],
     "dev": {
-      "IMAGE_PATH_AND_TAG": "ghcr.io/sage-bionetworks/schematic:schematic:v23.12.1",
+      "IMAGE_PATH_AND_TAG": "ghcr.io/sage-bionetworks/schematic:v23.12.1",
       "AWS_DEFAULT_REGION": "us-east-1",
       "PORT": "443",
       "TAGS": {

--- a/cdk.json
+++ b/cdk.json
@@ -31,7 +31,7 @@
       "aws-cn"
     ],
     "dev": {
-      "IMAGE_PATH_AND_TAG": "ghcr.io/sage-bionetworks/schematic:v23.12.1",
+      "IMAGE_PATH_AND_TAG": "ghcr.io/sage-bionetworks/schematic:0.1.62-beta",
       "AWS_DEFAULT_REGION": "us-east-1",
       "PORT": "443",
       "TAGS": {

--- a/cdk.json
+++ b/cdk.json
@@ -31,7 +31,7 @@
       "aws-cn"
     ],
     "dev": {
-      "IMAGE_PATH_AND_TAG": "ghcr.io/sage-bionetworks/schematic:0.1.62-beta",
+      "IMAGE_PATH_AND_TAG": "ghcr.io/sage-bionetworks/schematic:schematic:v23.12.1",
       "AWS_DEFAULT_REGION": "us-east-1",
       "PORT": "443",
       "TAGS": {

--- a/docker_fargate/docker_fargate_stack.py
+++ b/docker_fargate/docker_fargate_stack.py
@@ -90,7 +90,7 @@ class DockerFargateStack(Stack):
             task_image_options=task_image_options,
             memory_limit_mib=8192,      # Default is 512; 8192 MiB is equivalent to 8GB.
             public_load_balancer=True,  # Default is False
-            idle_timeout=Duration.seconds(300),
+            idle_timeout=Duration.seconds(300), # Modify default idle time out to avoid 504 gateway error
             # TLS:
             certificate=cert,
             protocol=elbv2.ApplicationProtocol.HTTPS,

--- a/docker_fargate/docker_fargate_stack.py
+++ b/docker_fargate/docker_fargate_stack.py
@@ -90,7 +90,7 @@ class DockerFargateStack(Stack):
             task_image_options=task_image_options,
             memory_limit_mib=8192,      # Default is 512; 8192 MiB is equivalent to 8GB.
             public_load_balancer=True,  # Default is False
-            idle_timeout=300,
+            idle_timeout=Duration.seconds(300),
             # TLS:
             certificate=cert,
             protocol=elbv2.ApplicationProtocol.HTTPS,

--- a/docker_fargate/docker_fargate_stack.py
+++ b/docker_fargate/docker_fargate_stack.py
@@ -90,6 +90,7 @@ class DockerFargateStack(Stack):
             task_image_options=task_image_options,
             memory_limit_mib=8192,      # Default is 512; 8192 MiB is equivalent to 8GB.
             public_load_balancer=True,  # Default is False
+            idle_timeout=300,
             # TLS:
             certificate=cert,
             protocol=elbv2.ApplicationProtocol.HTTPS,


### PR DESCRIPTION
PR Checklist:
[ ] Describe and explain your intentions for this change
[ ] Setup pre-commit and run the validators (info in README.md)

Based on the documentation [here](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#connection-idle-timeout), connection idle time out controls two connections: 1) the connection between the ALB and the client; 2) the connection between the ALB and the target. If no data has been sent or received by the time that the idle timeout period elapses, the ALB closes the connection. This is a PR to increase the idle connection time out. 

JIRA: [FDS-1665](https://sagebionetworks.jira.com/browse/FDS-1665)

 


[FDS-1665]: https://sagebionetworks.jira.com/browse/FDS-1665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ