### PR TITLE
[bug fix] use a different file path for mono repo deployment 

### DIFF
--- a/docker_fargate/docker_fargate_stack.py
+++ b/docker_fargate/docker_fargate_stack.py
@@ -103,7 +103,7 @@ class DockerFargateStack(Stack):
 
         # The number of consecutive health check failures required before considering a target unhealthy. For Application Load Balancers, the default is 2.
         #
-        load_balanced_fargate_service.target_group.configure_health_check(protocol=elbv2.Protocol.HTTPS, interval=Duration.seconds(120), timeout=Duration.seconds(60), path="/v1/ui/", healthy_http_codes="200-308", unhealthy_threshold_count=5)
+        load_balanced_fargate_service.target_group.configure_health_check(protocol=elbv2.Protocol.HTTPS, interval=Duration.seconds(120), timeout=Duration.seconds(60), path="/api/v1/ui/", healthy_http_codes="200-308", unhealthy_threshold_count=5)
 
         if True: # enable/disable autoscaling
             scalable_target = load_balanced_fargate_service.service.auto_scale_task_count(


### PR DESCRIPTION
PR Checklist:
[ ] Describe and explain your intentions for this change
[ ] Setup pre-commit and run the validators (info in README.md)

https://github.com/Sage-Bionetworks/schematic-infra/pull/116 triggered a deployment failure. I think the issue is because file path wasn't correct. 
