### PR TITLE
[IT-3975] Opentelemetry collector as a gateway

### DIFF
--- a/.github/workflows/aws-deploy.yml
+++ b/.github/workflows/aws-deploy.yml
@@ -124,35 +124,6 @@ jobs:
           cdk_args: '--require-approval never --context env=dev-refactor --progress events --debug'
           actions_comment: false
 
-  cdk-deploy-sandbox:
-    runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/it-3975-opentelemetry-collector-deployment' }}
-    needs: tests
-    permissions:
-      id-token: write
-      contents: read
-      packages: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
-        # Authenticate to AWS using GitHub OIDC
-      - name: Assume AWS Role
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-region: us-east-1
-          role-to-assume: arn:aws:iam::631692904429:role/sagebase-github-oidc-sage-bionetworks-schematic-infra
-          role-session-name: GitHubActions-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
-          role-duration-seconds: 1200
-
-      - name: cdk deploy to org-sagebase-dnt-dev (631692904429)
-        uses: youyo/aws-cdk-github-actions@v2
-        with:
-          cdk_subcommand: 'deploy'
-          cdk_args: '--require-approval never --context env=dev-sandbox --progress events --debug'
-          actions_comment: false
-
   cdk-deploy-prod:
     runs-on: ubuntu-latest
     if: ${{ github.ref == 'refs/heads/prod' }}

--- a/.github/workflows/aws-deploy.yml
+++ b/.github/workflows/aws-deploy.yml
@@ -124,6 +124,35 @@ jobs:
           cdk_args: '--require-approval never --context env=dev-refactor --progress events --debug'
           actions_comment: false
 
+  cdk-deploy-sandbox:
+    runs-on: ubuntu-latest
+    if: ${{ github.ref == 'refs/heads/it-3975-opentelemetry-collector-deployment' }}
+    needs: tests
+    permissions:
+      id-token: write
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+        # Authenticate to AWS using GitHub OIDC
+      - name: Assume AWS Role
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: us-east-1
+          role-to-assume: arn:aws:iam::631692904429:role/sagebase-github-oidc-sage-bionetworks-schematic-infra
+          role-session-name: GitHubActions-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
+          role-duration-seconds: 1200
+
+      - name: cdk deploy to org-sagebase-dnt-dev (631692904429)
+        uses: youyo/aws-cdk-github-actions@v2
+        with:
+          cdk_subcommand: 'deploy'
+          cdk_args: '--require-approval never --context env=dev-sandbox --progress events --debug'
+          actions_comment: false
+
   cdk-deploy-prod:
     runs-on: ubuntu-latest
     if: ${{ github.ref == 'refs/heads/prod' }}

--- a/cdk.json
+++ b/cdk.json
@@ -52,6 +52,17 @@
       "ACM_CERT_ARN": "arn:aws:acm:us-east-1:631692904429:certificate/0e9682f6-3ffa-46fb-9671-b6349f5164d6",
       "VPC_CIDR": "10.255.76.0/24"
     },
+    "dev-sandbox": {
+      "IMAGE_PATH_AND_TAG": "ghcr.io/sage-bionetworks/schematic:v0.1.90-beta",
+      "AWS_DEFAULT_REGION": "us-east-1",
+      "PORT": "443",
+      "TAGS": {
+        "CostCenter": "NO PROGRAM / 000000"
+      },
+      "STACK_NAME_PREFIX": "schematic-dev-sandbox",
+      "ACM_CERT_ARN": "arn:aws:acm:us-east-1:631692904429:certificate/0e9682f6-3ffa-46fb-9671-b6349f5164d6",
+      "VPC_CIDR": "10.255.77.0/24"
+    },
     "staging": {
       "IMAGE_PATH_AND_TAG": "ghcr.io/sage-bionetworks/schematic:v24.10.2",
       "AWS_DEFAULT_REGION": "us-east-1",

--- a/docker_fargate/docker_fargate_stack.py
+++ b/docker_fargate/docker_fargate_stack.py
@@ -1,12 +1,11 @@
 from aws_cdk import (Stack,
-    aws_ec2 as ec2,
-    aws_ecs as ecs,
-    aws_ecs_patterns as ecs_patterns,
-    aws_elasticloadbalancingv2 as elbv2,
-    aws_route53 as r53,
-    CfnOutput,
-    Duration,
-    Tags)
+                     aws_ec2 as ec2,
+                     aws_ecs as ecs,
+                     aws_ecs_patterns as ecs_patterns,
+                     aws_elasticloadbalancingv2 as elbv2,
+                     CfnOutput,
+                     Duration,
+                     Tags)
 
 import config as config
 import aws_cdk.aws_certificatemanager as cm
@@ -19,8 +18,9 @@ PORT_NUMBER_CONTEXT = "PORT"
 
 # The name of the environment variable that will hold the secrets
 SECRETS_MANAGER_ENV_NAME = "SECRETS_MANAGER_SECRETS"
-CONTAINER_ENV = "CONTAINER_ENV" # name of env passed from GitHub action
+CONTAINER_ENV = "CONTAINER_ENV"  # name of env passed from GitHub action
 ENV_NAME = "ENV"
+
 
 def get_secret(scope: Construct, id: str, name: str) -> str:
     isecret = sm.Secret.from_secret_name_v2(scope, id, name)
@@ -28,14 +28,18 @@ def get_secret(scope: Construct, id: str, name: str) -> str:
     # see also: https://docs.aws.amazon.com/cdk/api/v1/python/aws_cdk.aws_ecs/Secret.html
     # see also: ecs.Secret.from_ssm_parameter(ssm.IParameter(parameter_name=name))
 
+
 def get_container_env(env: dict) -> str:
     return env.get(CONTAINER_ENV)
+
 
 def get_certificate_arn(env: dict) -> str:
     return env.get(ACM_CERT_ARN_CONTEXT)
 
+
 def get_docker_image_name(env: dict):
     return env.get(IMAGE_PATH_AND_TAG_CONTEXT)
+
 
 def get_port(env: dict) -> int:
     return int(env.get(PORT_NUMBER_CONTEXT))
@@ -56,19 +60,20 @@ class DockerFargateStack(Stack):
 
         secret_name = f'{stack_id}/{context}/ecs'
         secrets = {
-            SECRETS_MANAGER_ENV_NAME: get_secret(self, secret_name, secret_name)
+            SECRETS_MANAGER_ENV_NAME: get_secret(
+                self, secret_name, secret_name)
         }
 
         env_vars = {}
         container_env = get_container_env(env)
         if container_env is not None:
-            env_vars[ENV_NAME]=container_env
+            env_vars[ENV_NAME] = container_env
 
         task_image_options = ecs_patterns.ApplicationLoadBalancedTaskImageOptions(
-                   image=ecs.ContainerImage.from_registry(get_docker_image_name(env)),
-                   environment=env_vars,
-                   secrets = secrets,
-                   container_port = get_port(env))
+            image=ecs.ContainerImage.from_registry(get_docker_image_name(env)),
+            environment=env_vars,
+            secrets=secrets,
+            container_port=get_port(env))
 
         cert = cm.Certificate.from_certificate_arn(
             self,
@@ -85,17 +90,22 @@ class DockerFargateStack(Stack):
             f'{stack_prefix}-Service',
             cluster=cluster,            # Required
             cpu=4096,                    # Default is 256 which is 0.25vCPU; 4096 is 4 vCPU
-            desired_count=3,            # Number of copies of the 'task' (i.e. the app') running behind the ALB
-            circuit_breaker=ecs.DeploymentCircuitBreaker(rollback=True), # Enable rollback on deployment failure
+            # Number of copies of the 'task' (i.e. the app') running behind the ALB
+            desired_count=3,
+            circuit_breaker=ecs.DeploymentCircuitBreaker(
+                rollback=True),  # Enable rollback on deployment failure
             task_image_options=task_image_options,
-            memory_limit_mib=8192,      # Default is 512; 8192 MiB is equivalent to 8GB.
+            # Default is 512; 8192 MiB is equivalent to 8GB.
+            memory_limit_mib=8192,
             public_load_balancer=True,  # Default is False
-            idle_timeout=Duration.seconds(300), # Modify default idle time out to avoid 504 gateway error
+            # Modify default idle time out to avoid 504 gateway error
+            idle_timeout=Duration.seconds(300),
             # TLS:
             certificate=cert,
             protocol=elbv2.ApplicationProtocol.HTTPS,
             target_protocol=elbv2.ApplicationProtocol.HTTPS,
-            ssl_policy=elbv2.SslPolicy.FORWARD_SECRECY_TLS12_RES, # Strong forward secrecy ciphers and TLS1.2 only.
+            # Strong forward secrecy ciphers and TLS1.2 only.
+            ssl_policy=elbv2.SslPolicy.FORWARD_SECRECY_TLS12_RES,
         )
 
         # Overriding health check timeout helps with sluggishly responding app's (e.g. Shiny)
@@ -103,23 +113,24 @@ class DockerFargateStack(Stack):
 
         # The number of consecutive health check failures required before considering a target unhealthy. For Application Load Balancers, the default is 2.
         #
-        load_balanced_fargate_service.target_group.configure_health_check(protocol=elbv2.Protocol.HTTPS, interval=Duration.seconds(120), timeout=Duration.seconds(60), path="/v1/ui/", healthy_http_codes="200-308", unhealthy_threshold_count=5)
+        load_balanced_fargate_service.target_group.configure_health_check(protocol=elbv2.Protocol.HTTPS, interval=Duration.seconds(
+            120), timeout=Duration.seconds(60), path="/v1/ui/", healthy_http_codes="200-308", unhealthy_threshold_count=5)
 
-        if True: # enable/disable autoscaling
+        if True:  # enable/disable autoscaling
             scalable_target = load_balanced_fargate_service.service.auto_scale_task_count(
-               min_capacity=3, # Minimum capacity to scale to. Default: 1
-               max_capacity=5 # Maximum capacity to scale to.
+                min_capacity=3,  # Minimum capacity to scale to. Default: 1
+                max_capacity=5  # Maximum capacity to scale to.
             )
 
             # Add more capacity when CPU utilization reaches 50%
             scalable_target.scale_on_cpu_utilization("CpuScaling",
-                target_utilization_percent=50
-            )
+                                                     target_utilization_percent=50
+                                                     )
 
             # Add more capacity when memory utilization reaches 50%
             scalable_target.scale_on_memory_utilization("MemoryScaling",
-                target_utilization_percent=50
-            )
+                                                        target_utilization_percent=50
+                                                        )
 
             # Other metrics to drive scaling are discussed here:
             # https://docs.aws.amazon.com/cdk/api/v1/python/aws_cdk.aws_autoscaling/README.html
@@ -131,4 +142,73 @@ class DockerFargateStack(Stack):
         # Export load balancer name
         lb_dns_name = load_balanced_fargate_service.load_balancer.load_balancer_dns_name
         lb_dns_export_name = f'{stack_id}-LoadBalancerDNS'
-        CfnOutput(self, 'LoadBalancerDNS', value=lb_dns_name, export_name=lb_dns_export_name)
+        CfnOutput(self, 'LoadBalancerDNS', value=lb_dns_name,
+                  export_name=lb_dns_export_name)
+
+        # Opentelemetry collector
+        task_image_options_collector = ecs_patterns.ApplicationLoadBalancedTaskImageOptions(
+            image=ecs.ContainerImage.from_registry(
+                name="public.ecr.aws/aws-observability/aws-otel-collector:latest"),
+
+            # TODO ----------------------------
+            # The AWS Distro for OpenTelemetry Collector can optionally be configured
+            # via an environment variable AOT_CONFIG_CONTENT. The value of this variable
+            # is expected to be a full Collector configuration file; it will override
+            # the config file used in the Collector entrypoint command. In ECS, the
+            # values of environment variables can be set from AWS Systems Manager Parameters.
+
+            #    environment=env_vars,
+            # TODO: Pull secrets for authentication from AWS Secrets Manager
+            #    secrets = secrets,
+            # TODO ----------------------------
+            container_port=4318)
+
+        load_balanced_fargate_otel_collector_service = ecs_patterns.ApplicationLoadBalancedFargateService(
+            self,
+            f'{stack_prefix}-otel-collector-Service',
+            cluster=cluster,            # Required
+            cpu=500,                    # Default is 256 which is 0.25vCPU; 500 is 0.5 vCPU
+            # Number of copies of the 'task' (i.e. the app') running behind the ALB
+            desired_count=1,
+            circuit_breaker=ecs.DeploymentCircuitBreaker(
+                rollback=True),  # Enable rollback on deployment failure
+            task_image_options=task_image_options_collector,
+            # Default is 512; 1024 MiB is equivalent to 1GB.
+            memory_limit_mib=1024,
+            public_load_balancer=False,  # Default is False
+            # Modify default idle time out to avoid 504 gateway error
+            idle_timeout=Duration.seconds(300),
+            # TLS:
+            certificate=cert,
+            protocol=elbv2.ApplicationProtocol.HTTPS,
+            target_protocol=elbv2.ApplicationProtocol.HTTPS,
+            # Strong forward secrecy ciphers and TLS1.2 only.
+            ssl_policy=elbv2.SslPolicy.FORWARD_SECRECY_TLS12_RES,
+            # TODO: What is the method to configure service discovery?
+            # cloud_map_options=ecs.CloudMapOptions(
+            #     cloud_map_namespace=ecs.CloudMapNamespaceOptions())
+        )
+
+        load_balanced_fargate_otel_collector_service.target_group.configure_health_check(protocol=elbv2.Protocol.HTTPS, interval=Duration.seconds(
+            5), timeout=Duration.seconds(3), path="/healthcheck", healthy_http_codes="200-308", unhealthy_threshold_count=5)
+
+        if True:  # enable/disable autoscaling
+            scalable_target_otel_collector = load_balanced_fargate_otel_collector_service.service.auto_scale_task_count(
+                min_capacity=1,  # Minimum capacity to scale to. Default: 1
+                max_capacity=3  # Maximum capacity to scale to.
+            )
+
+            # Add more capacity when CPU utilization reaches 70%
+            scalable_target_otel_collector.scale_on_cpu_utilization("CpuScaling",
+                                                                    target_utilization_percent=70
+                                                                    )
+
+            # Add more capacity when memory utilization reaches 70%
+            scalable_target_otel_collector.scale_on_memory_utilization("MemoryScaling",
+                                                                       target_utilization_percent=70
+                                                                       )
+
+        lb_dns_name_collector = load_balanced_fargate_otel_collector_service.load_balancer.load_balancer_dns_name
+        lb_dns_export_name_collector = f'{stack_id}-otel-collector-LoadBalancerDNS'
+        CfnOutput(self, 'LoadBalancerDNS', value=lb_dns_name_collector,
+                  export_name=lb_dns_export_name_collector)

--- a/docker_fargate/docker_fargate_stack.py
+++ b/docker_fargate/docker_fargate_stack.py
@@ -146,6 +146,12 @@ class DockerFargateStack(Stack):
                   export_name=lb_dns_export_name)
 
         # Opentelemetry collector
+
+        secret_name_otel_config = f'{stack_id}/{context}/otel-collector-config'
+        secrets_otel_config = {
+            "AOT_CONFIG_CONTENT": get_secret(
+                self, secret_name_otel_config, secret_name_otel_config)
+        }
         task_image_options_collector = ecs_patterns.ApplicationLoadBalancedTaskImageOptions(
             image=ecs.ContainerImage.from_registry(
                 name="public.ecr.aws/aws-observability/aws-otel-collector:latest"),
@@ -159,7 +165,8 @@ class DockerFargateStack(Stack):
 
             #    environment=env_vars,
             # TODO: Pull secrets for authentication from AWS Secrets Manager
-            #    secrets = secrets,
+            # TODO: Secret for telemetry needs to be put into an enironment variable "AOT_CONFIG_CONTENT"
+            secrets=secrets_otel_config,
             # TODO ----------------------------
             container_port=4318)
 
@@ -210,5 +217,5 @@ class DockerFargateStack(Stack):
 
         lb_dns_name_collector = load_balanced_fargate_otel_collector_service.load_balancer.load_balancer_dns_name
         lb_dns_export_name_collector = f'{stack_id}-otel-collector-LoadBalancerDNS'
-        CfnOutput(self, 'LoadBalancerDNS', value=lb_dns_name_collector,
+        CfnOutput(self, 'OtelCollectorLoadBalancerDNS', value=lb_dns_name_collector,
                   export_name=lb_dns_export_name_collector)


### PR DESCRIPTION
Background:

1. One of the way to deploy an opentelemetry collector is as an ECS service (Gateway) for other services to access as described in this blog post: https://aws.amazon.com/blogs/opensource/deployment-patterns-for-the-aws-distro-for-opentelemetry-collector-with-amazon-elastic-container-service/

Problems to solve:

- [ ] How can we deploy the OTEL collector as a service to ECS Fargate
- [ ] How can we deploy multiple services to ECS and allow them to use AWS Service discovery to permit HTTPS traffic (https://github.com/Sage-Bionetworks/multi-services-ecs-demo/tree/dev POC work)
- [ ] How can we inject configuration securely and secretly as shown in this example with the `oauth2client` extension for the collector? (https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/oauth2clientauthextension) - One example described in https://aws-otel.github.io/docs/setup/ecs/config-through-ssm is to use the value of an environment variable set from AWS System Manager Parameters. Sage uses AWS Secrets manager, and per the documentation all that should need to be set is the `AOT_CONFIG_CONTENT` environment variable.